### PR TITLE
Fixed invalid product alternative mapping process

### DIFF
--- a/contribution-license-agreement.txt
+++ b/contribution-license-agreement.txt
@@ -1,0 +1,1 @@
+I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/product-alternative-storage/blob/de4b9de6fdc0b239bd2dd0930cdeec4f262d876a/CONTRIBUTING.md.

--- a/src/Spryker/Client/ProductAlternativeStorage/ProductAlternativeMapper/ProductAlternativeMapper.php
+++ b/src/Spryker/Client/ProductAlternativeStorage/ProductAlternativeMapper/ProductAlternativeMapper.php
@@ -72,7 +72,8 @@ class ProductAlternativeMapper implements ProductAlternativeMapperInterface
                 continue;
             }
 
-            $productViewTransferList[] = clone $productViewTransfer->fromArray($concreteProductViewTransfer->modifiedToArray());
+            $productViewTransfer = clone $productViewTransfer;
+            $productViewTransferList[] = $productViewTransfer->fromArray($concreteProductViewTransfer->modifiedToArray());
         }
 
         return array_filter($productViewTransferList);


### PR DESCRIPTION
## PR Description
Bugfix for invalid product alternatives mapping issue causing incorrect `Alternatives for` product name shown on the Shopping List page.
![Screenshot 2025-04-04 at 11 48 18](https://github.com/user-attachments/assets/e0981e41-bed3-4fd3-9474-c37843c118b7)


Steps to reproduce the issue:

1. Login to [YVES](https://www.b2b-eu.demo-spryker.com/) as `sonia@spryker.com`.
2. Select any Shopping List from Sonia's top menu list.
3. Add selected product to the Shopping List (for the case from screenshot above I've added Product `potato-1` to the Shopping List).
4. Login as BO Administrator to [BackOffice](https://backoffice.b2b-eu.demo-spryker.com/).
5. Go to `Catalog` -> `Products` and add Product Alternatives to the selected product's VARIANT (in the scenario from screenshot above, I've added random products as Product Alternatives to the `potato-1` product variant).
6. Set `potato-1` product VARIANT as `Discontinued`.
7. Go to Sonia's Shopping List where `potato-1` has been added to the product list.
8. See that there is invalid product name shown in `Alternative for` title section.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
